### PR TITLE
Add ts-node options to avoid windows errors with Node v20.19.0

### DIFF
--- a/exercises/javascript/app/tsconfig.json
+++ b/exercises/javascript/app/tsconfig.json
@@ -17,5 +17,10 @@
     "lib": ["esnext"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist/**/*", "**/*.test.ts", "node_modules/**/*"]
+  "exclude": ["dist/**/*", "**/*.test.ts", "node_modules/**/*"],
+  "ts-node": {
+    "experimentalSpecifierResolution": "node",
+    "transpileOnly": true,
+    "esm": true
+  }
 }


### PR DESCRIPTION
Without this code:

node:internal/modules/run_main:123
    triggerUncaughtException(
    ^
[Object: null prototype] {
  [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
}